### PR TITLE
Newline in the pdf and deleting pngs after pdf creation

### DIFF
--- a/txttohandwriting.py
+++ b/txttohandwriting.py
@@ -97,3 +97,7 @@ pdf_creation(imagelist.pop(0))
 #Appending them to pdfs
 for PNG_FILE in imagelist:
     pdf_creation(PNG_FILE, flag=True)
+img_num=0
+while os.path.exists(str(img_num)+"outt.png"):
+    os.remove(str(img_num)+"outt.png")
+    img_num+=1

--- a/txttohandwriting.py
+++ b/txttohandwriting.py
@@ -14,6 +14,9 @@ def writee(char):
         BG.paste(cases, (gap, _))
         size = cases.width
         gap += size
+    else:
+        gap=0
+        _+=200
 
 def letterwrite(word):
     global gap, _
@@ -28,9 +31,16 @@ def letterwrite(word):
             elif letter.isupper():
                 letter = letter.lower()
                 letter += 'upper'
-            elif special_char[letter] != None:
-                letter = special_char[letter]
+            else:
+                try:
+                    if special_char[letter] != None:
+                        letter = special_char[letter]
+                except:
+                    pass
             writee(letter)
+        else:
+            gap=0
+            _+=200
 
 
 def worddd(Input):


### PR DESCRIPTION
Unallowed character (for ex- ":" (colon)) will now create a new line in the generated pdf.
Xoutt.png will now be deleted after PDF creation.